### PR TITLE
chore: add PKGBUILD for Arch Linux packages

### DIFF
--- a/ArchLinux/PKGBUILD
+++ b/ArchLinux/PKGBUILD
@@ -1,0 +1,20 @@
+pkgname=pipe_exec
+pkgver=master
+pkgrel=1
+pkgdesc="Execute ELF binaries from pipes, stdin and ttys"
+arch=('x86_64')
+url="https://github.com/koraa/pipe_exec"
+license=('MIT')
+source=("${pkgname}-${pkgvar}.tar.gz::https://github.com/koraa/pipe_exec/archive/refs/heads/master.tar.gz")
+sha256sums=('SKIP')
+
+build() {
+	cd "$pkgname-$pkgver"
+	make DESTDIR="$pkgdir/" PREFIX=/usr
+}
+
+package() {
+	cd "$pkgname-$pkgver"
+        install -Dm644 COPYING -t "${pkgdir}/usr/share/licenses/${pkgname}/"
+        make DESTDIR="$pkgdir/" PREFIX=/usr install
+}


### PR DESCRIPTION
Since there is no release version, "master" is used as the package version. This is a temporary workaround and should be updated later.